### PR TITLE
ENH: add script for visualizing images, to do quality control.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 ica_maps/
 ica_imgs/
 ica_nii/
+qc/
 
 # Nilearn
 nilearn_cache/

--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ from nilearn import datasets
 from nilearn.image import index_img, iter_img
 
 from nibabel_ext import NiftiImageWithTerms
-from nilearn_ext.datasets import fetch_neurovault_images_and_terms
+from nilearn_ext.datasets import fetch_neurovault
 from nilearn_ext.decomposition import compare_components, generate_components
 from nilearn_ext.masking import join_bilateral_rois
 from nilearn_ext.plotting import (plot_comparisons, plot_components,
@@ -65,7 +65,7 @@ def mix_and_match_bilateral_components(**kwargs):
     return img
 
 
-def main(dataset, keys=('R', 'L'), n_components=20, n_images=np.inf,
+def main(dataset, keys=('R', 'L'), n_components=20, max_images=np.inf,
          scoring='l1norm', query_server=True,
          force=False, img_dir=None, plot_dir=None):
     this_dir = op.join(dataset, '%s-%dics' % (scoring, n_components))
@@ -74,10 +74,10 @@ def main(dataset, keys=('R', 'L'), n_components=20, n_images=np.inf,
 
     # Download
     if dataset == 'neurovault':
-        images, term_scores = fetch_neurovault_images_and_terms(
-            n_images=n_images, query_server=query_server)
+        images, term_scores = fetch_neurovault(
+            max_images=max_images, query_server=query_server)
     elif dataset == 'abide':
-        images = datasets.fetch_abide_pcp(n_subjects=n_images)
+        images = datasets.fetch_abide_pcp(n_subjects=max_images)
         term_scores = None
 
     # Analyze images

--- a/nilearn_ext/datasets.py
+++ b/nilearn_ext/datasets.py
@@ -6,25 +6,29 @@ import numpy as np
 from nilearn import datasets
 
 
-def fetch_neurovault_images_and_terms(n_images=np.inf, query_server=True):
-    # Get image and term data
+def fetch_neurovault(max_images=np.inf, query_server=True, fetch_terms=True,
+                     map_types=['F map', 'T map', 'Z map'], **kwargs):
+    """Give meaningful defaults, extra computations."""
 
     # Download matching images
-    ss_all = datasets.fetch_neurovault(max_images=n_images,
-                                       map_types=['F map', 'T map', 'Z map'],
-                                       query_server=query_server,
-                                       fetch_terms=True)
+    ss_all = datasets.fetch_neurovault(
+        max_images=max_images, query_server=query_server, map_types=map_types,
+        fetch_terms=fetch_terms, **kwargs)
     images = ss_all['images']
-    term_scores = ss_all['terms']
 
-    # Clean & report term scores
-    terms = np.array(term_scores.keys())
-    term_matrix = np.asarray(term_scores.values())
-    term_matrix[term_matrix < 0] = 0
-    total_scores = np.mean(term_matrix, axis=1)
+    if not fetch_terms:
+        term_scores = None
+    else:
+        term_scores = ss_all['terms']
 
-    print("Top 10 neurosynth terms from downloaded images:")
-    for term_idx in np.argsort(total_scores)[-10:][::-1]:
-        print('\t%-25s: %.2f' % (terms[term_idx], total_scores[term_idx]))
+        # Clean & report term scores
+        terms = np.array(term_scores.keys())
+        term_matrix = np.asarray(term_scores.values())
+        term_matrix[term_matrix < 0] = 0
+        total_scores = np.mean(term_matrix, axis=1)
+
+        print("Top 10 neurosynth terms from downloaded images:")
+        for term_idx in np.argsort(total_scores)[-10:][::-1]:
+            print('\t%-25s: %.2f' % (terms[term_idx], total_scores[term_idx]))
 
     return images, term_scores

--- a/qc.py
+++ b/qc.py
@@ -1,0 +1,52 @@
+"""
+This script helps visualize brains, to validate
+what looks good and what looks like crap.
+"""
+
+import os.path as op
+
+import matplotlib.pyplot as plt
+import numpy as np
+from nilearn import datasets
+from nilearn.plotting import plot_stat_map
+from sklearn.externals.joblib import Memory
+
+from nilearn_ext.image import clean_img, cast_img
+from nilearn_ext.masking import MniNiftiMasker
+from nilearn_ext.plotting import save_and_close
+
+# Download matching images
+ss_all = datasets.fetch_neurovault(max_images=np.inf,
+                                   map_types=['F map', 'T map', 'Z map'],
+                                   query_server=False,
+                                   fetch_terms=False)
+images = ss_all['images']
+masker = MniNiftiMasker(memory=Memory(cachedir='nilearn_cache')).fit()
+
+for ii, image in enumerate(images):
+    ri = ii % 4  # row i
+    ci = (ii / 4) % 4  # column i
+    pi = ii % 16 + 1  # plot i
+    fi = ii / 16  # figure i
+
+    if ri == 0 and ci == 0:
+        fh = plt.figure(figsize=(16, 10))
+        print('Plot %03d of %d' % (fi + 1, np.ceil(len(images) / 16.)))
+    ax = fh.add_subplot(4, 4, pi)
+    title = op.join(str(image['collection_id']), str(image['id']),
+                    op.basename(image['local_path']))
+
+    # Images may fail to be transformed, and are of different shapes,
+    # so we need to trasnform one-by-one and keep track of failures.
+    img = cast_img(image['local_path'], dtype=np.float32)
+    img = clean_img(img)
+    try:
+        img = masker.inverse_transform(masker.transform(img))
+    except Exception as e:
+        print("Failed to mask/reshape image %s: %s" % (title, e))
+
+    plot_stat_map(img, axes=ax, black_bg=True, title=title, colorbar=False)
+
+    if (ri == 3 and ci == 3) or ii == len(images) - 1:
+        out_path = op.join('qc', 'fig%03d.png' % (fi + 1))
+        save_and_close(out_path)

--- a/qc.py
+++ b/qc.py
@@ -4,24 +4,26 @@ what looks good and what looks like crap.
 """
 
 import os.path as op
+import shutil
 
 import matplotlib.pyplot as plt
 import numpy as np
-from nilearn import datasets
 from nilearn.plotting import plot_stat_map
 from sklearn.externals.joblib import Memory
 
+from nilearn_ext.datasets import fetch_neurovault
 from nilearn_ext.image import clean_img, cast_img
 from nilearn_ext.masking import MniNiftiMasker
 from nilearn_ext.plotting import save_and_close
 
 # Download matching images
-ss_all = datasets.fetch_neurovault(max_images=np.inf,
-                                   map_types=['F map', 'T map', 'Z map'],
-                                   query_server=False,
-                                   fetch_terms=False)
-images = ss_all['images']
+images = fetch_neurovault(fetch_terms=False, query_server=True)[0]
+plot_dir = 'qc'
+
+# Get ready
 masker = MniNiftiMasker(memory=Memory(cachedir='nilearn_cache')).fit()
+if op.exists(plot_dir):  # Delete old plots.
+    shutil.rmtree(plot_dir)
 
 for ii, image in enumerate(images):
     ri = ii % 4  # row i


### PR DESCRIPTION
This is a simple script that goes through each image, runs the clean/masking procedures on it, then visualizes it. We can use this for quality control of our images.

@atsuch Can you try this out? There are a *lot* of threshholded maps, and I'm not sure if we want to use them or not. It's only 96 images to look through; images look like this:

![fig023](https://cloud.githubusercontent.com/assets/4072455/12007137/9a2b8e2c-abab-11e5-86d8-c98596e50772.png)
