### PR TITLE
Enable ABIDE and NYU datasets

### DIFF
--- a/nilearn_ext/plotting.py
+++ b/nilearn_ext/plotting.py
@@ -25,6 +25,9 @@ def save_and_close(out_path, fh=None):
 
 def _title_from_terms(terms, ic_idx, label=None, n_terms=4):
 
+    if terms is None:
+        return '%s[%d]' % (label, ic_idx)
+
     # Use the 4 terms weighted most as a title
     ica_terms = np.asarray(terms.values()).T
     ic_terms = ica_terms[ic_idx]

--- a/qc.py
+++ b/qc.py
@@ -11,6 +11,7 @@ import numpy as np
 from nilearn.plotting import plot_stat_map
 from sklearn.externals.joblib import Memory
 
+from main import get_dataset
 from nilearn_ext.datasets import fetch_neurovault
 from nilearn_ext.image import clean_img, cast_img
 from nilearn_ext.masking import MniNiftiMasker
@@ -31,9 +32,10 @@ def qc_image_metadata(**kwargs):
         print("")
 
 
-def qc_image_data(**kwargs):
+def qc_image_data(dataset, **kwargs):
     # Download matching images
-    images = fetch_neurovault(fetch_terms=False, **kwargs)[0]
+    kwargs['fetch_terms'] = False
+    images = get_dataset(dataset, **kwargs)[0]
     plot_dir = 'qc'
 
     # Get ready
@@ -86,6 +88,8 @@ if __name__ == '__main__':
     parser.add_argument('check', nargs='?', default='data',
                         choices=('data', 'metadata'))
     parser.add_argument('--offline', action='store_true', default=False)
+    parser.add_argument('--dataset', nargs='?', default='neurovault',
+                        choices=['neurovault', 'abide', 'nyu'])
     args = vars(parser.parse_args())
 
     # Alias args


### PR DESCRIPTION
With these changes, pretty much any existing `nilearn` or `nidata` dataset could work. In fact, with a bit of a push, we could get HCP data running with this code.

Simple changes:
* Add code to select the correct download function.
* All functions now accept images as paths (or loaded via `nibabel`), rather than expecting images as neurovault metadata (dicts)
* Make sure all functions can accept when `terms is None`
