### PR TITLE
ENH: reorder rows, prioritize by top-2 max difference

### DIFF
--- a/nilearn_ext/plotting.py
+++ b/nilearn_ext/plotting.py
@@ -120,10 +120,10 @@ def plot_comparison_matrix(score_mat, scoring, normalize=True, out_dir=None,
                            keys=('R', 'L'), vmax=None, colorbar=True):
 
     # Settings
-    score_mat, x_idx = reorder_mat(score_mat, normalize=normalize)
+    score_mat, x_idx, y_idx = reorder_mat(score_mat, normalize=normalize)
     idx = np.arange(score_mat.shape[0])
-    vmax = vmax or min(score_mat.max(), 10 if normalize else np.inf)
-    vmin = 1 if normalize else 0
+    vmax = vmax  # or min(score_mat.max(), 10 if normalize else np.inf)
+    vmin = 0  # 1 if normalize else 0
 
     # Plotting
     fh = plt.figure(figsize=(10, 10))
@@ -132,7 +132,7 @@ def plot_comparison_matrix(score_mat, scoring, normalize=True, out_dir=None,
     ax.set_xlabel("%s components" % (keys[1]))
     ax.set_ylabel("%s components" % (keys[0]))
     ax.set_xticks(idx), ax.set_xticklabels(x_idx)
-    ax.set_yticks(idx), ax.set_yticklabels(idx)
+    ax.set_yticks(idx), ax.set_yticklabels(y_idx)
     if colorbar:
         fh.colorbar(cax)
 


### PR DESCRIPTION
This addresses two things:
1. The component matching was tweaked such that rows with the clearest preference for a column gets to match first (take two lowest distance scores, subtract & normalize, allow largest value to select first).
2. Rows get reordered according to the same score.
3. Normalize by subtracting off the lowest similarity score... no division.

@atsuch It's looking reasonable:

![r_l_simmat](https://cloud.githubusercontent.com/assets/4072455/12763467/7f79be8e-c9a9-11e5-8c99-21e682bbe62e.png)
![r_l_simmat-normalized](https://cloud.githubusercontent.com/assets/4072455/12763468/7f7c62ba-c9a9-11e5-95a0-8f5b163175e2.png)


